### PR TITLE
Handled bug in route and added status chaining

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -28,7 +28,7 @@ const  method = data.method
     console.log("pathController: " + path);
 
     // Check if the path exists in the context.routes
-    const route = context.routes.find(route => route.path === path);
+    const route = context.routes.find(route => route.path === path && route.method === method);
     
     if (route && route.method === method) {
         route.callback(data, socket);

--- a/server/response.js
+++ b/server/response.js
@@ -4,7 +4,7 @@ class Response {
     }
 
     // Method to set status code
-    sendStatus(code) {
+    status(code) {
         this.statusCode = code;
         return this;
     }
@@ -17,7 +17,8 @@ class Response {
 
     // Method to send a response with a body
     send(body) {
-        const response = `HTTP/1.1 200 OK\n\n${body}`;
+        const statusCode = this.statusCode || 200;
+        const response = `HTTP/1.1 ${statusCode} OK\n\n${body}`;
         this.socket.write(response); // Send the complete response
         this.socket.end(); // End the connection
     }
@@ -37,8 +38,9 @@ class Response {
     }
 
 	json(data){
+        const statusCode = this.statusCode || 200;
 		data = JSON.stringify(data);
-		const  response = `HTTP/1.1 200 OK\nContent-Type: application/json\n\n${data}`;
+		const  response = `HTTP/1.1 ${statusCode} OK\nContent-Type: application/json\n\n${data}`;
 		this.send(response);
 	}
 }

--- a/test/test2.js
+++ b/test/test2.js
@@ -1,0 +1,32 @@
+const Server=  require('../server/index.js');
+const server  =  new Server();
+
+// this test is for "Add sending of status code with response AND handling of different method requests on same route" ISSUE N. #12
+
+// Test response in json format
+server.get("/",(req,res)=>{
+	console.log(req)
+	res.json({status:200})
+});
+
+// Test for handling different method requests on same route
+server.get('/hello', (req, res)=>{
+    res.send('Hello from GET request');
+});
+
+server.post('/hello', (req, res)=>{
+    res.send('Hello again from POST request');
+});
+
+// Test for chaining status codes with response, without chaining status code will default to 200
+server.get('/chain', (req, res)=>{
+    res.status(201).send('This req has status code of 201');
+});
+
+server.get('/chain-status', (req, res)=>{
+    res.status(202).json({message: "This req has status code of 202"});
+});
+
+server.listen(8080,()=>{
+	console.log("test")
+});


### PR DESCRIPTION
## Fixed issue #12 
### 1. Fixed bug of routes
Now different method requests on same route are working correctly.
```
server.get('/hello', (req, res)=>{
    res.send('Hello from GET request');
});

server.post('/hello', (req, res)=>{
    res.send('Hello again from POST request');
});
```
![image](https://github.com/user-attachments/assets/7fc87f1b-157d-428c-b29b-35050cb61779)
![image](https://github.com/user-attachments/assets/3690e521-8ddc-4996-9bc0-ee1e96048ae3)

### 2. Added support for status chaining
Now we can send status codes with responses. We can do this by chaining status method.
```
server.get('/chain', (req, res)=>{
    res.status(201).send('This req has status code of 201');
});
```


