### PR TITLE
feature/http-req-res 

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -55,7 +55,7 @@ class  Hasty extends Server{
 		this.socket.on('data', ()=> this.handler())
 	}
 
-	setRoute(method,object, status){
+	setRoute(method,object){
 		const route  =  new  Object();
 		route.callback = object.callback;
 		route.path  =  object.path;

--- a/server/index.js
+++ b/server/index.js
@@ -24,17 +24,14 @@ function handler(socket,context){
 
 function pathController(data,context, socket) {
     const path = data.path;
-const  method = data.method
-    console.log("pathController: " + path);
+	const  method = data.method
+    console.log("pathController: " + method + ": " + path);
 
     // Check if the path exists in the context.routes
-    const route = context.routes.find(route => route.path === path);
-    
-    if (route && route.method === method) {
-        route.callback(data, socket);
-    } else {
-        socket.sendStatus(404);
-    }
+    const route = context.routes.find(route => route.path === path && route.method === method);
+
+    if (route) route.callback(data, socket); 
+	else socket.sendStatus(404);
 }
 
 
@@ -55,14 +52,14 @@ class  Hasty extends Server{
 	 
 	constructor(){
 		super()
-		this.socket.on('data',()=>this.handler())
+		this.socket.on('data', ()=> this.handler())
 	}
 
-	setRoute(method,object){
+	setRoute(method,object, status){
 		const route  =  new  Object();
 		route.callback = object.callback;
 		route.path  =  object.path;
-		route.method=method;
+		route.method = method;
 		this.routes.push(route)
 		console.log(this.routes)
 	}
@@ -74,7 +71,22 @@ class  Hasty extends Server{
 	post(path,callback){
 		this.setRoute("POST",{callback:callback,path:path})
 	}
-	
+	put(path,callback){
+		this.setRoute("PUT",{callback:callback,path:path})
+	}
+	delete(path,callback){
+		this.setRoute("DELETE",{callback:callback,path:path})
+	}
+	patch(path,callback){
+		this.setRoute("PATCH",{callback:callback,path:path})
+	}
+	head(path,callback){
+		this.setRoute("HEAD",{callback:callback,path:path})
+	}
+	options(path,callback){
+		this.setRoute("OPTIONS",{callback:callback,path:path})
+	}
+
 }
 
 module.exports = Hasty

--- a/server/response.js
+++ b/server/response.js
@@ -1,10 +1,38 @@
 class Response {
+    statusCode = 200; // Default status code
+    statusTextMap = {
+        200: 'OK',
+        201: 'Created',
+        202: 'Accepted',
+        204: 'No Content',
+        301: 'Moved Permanently',
+        302: 'Found',
+        303: 'See Other',
+        304: 'Not Modified',
+        400: 'Bad Request',
+        401: 'Unauthorized',
+        403: 'Forbidden',
+        404: 'Not Found',
+        405: 'Method Not Allowed',
+        406: 'Not Acceptable',
+        409: 'Conflict',
+        417: 'Expectation Failed',
+        500: 'Internal Server Error',
+        501: 'Not Implemented',
+        503: 'Service Unavailable'
+        //... Add more status codes as needed
+    }; // Map of status codes to status text
+
     constructor(socket) {
         this.socket = socket;
     }
 
     // Method to set status code
-    sendStatus(code) {
+    status(code) {
+        if (this.statusTextMap[code] === undefined) {
+            throw new Error(`Invalid status code: ${code}`);
+        }
+
         this.statusCode = code;
         return this;
     }
@@ -17,15 +45,15 @@ class Response {
 
     // Method to send a response with a body
     send(body) {
-        const response = `HTTP/1.1 200 OK\n\n${body}`;
+        const response = `HTTP/1.1 ${this.statusCode} ${this.statusTextMap[this.statusCode]}\n\n${body}`;
         this.socket.write(response); // Send the complete response
         this.socket.end(); // End the connection
     }
 
     // Method to send only the status
     sendStatus(statusCode) {
-	const response = `HTTP/1.1 ${statusCode} \n\n`;
-	this.socket.write(response); // Send the complete response
+	    const response = `HTTP/1.1 ${statusCode} ${this.statusTextMap[this.statusCode]} \n\n`;
+	    this.socket.write(response); // Send the complete response
         this.socket.end(); // End the connection
     }
 
@@ -36,10 +64,11 @@ class Response {
             .join('\r\n');
     }
 
-	json(data){
+	json(data) {
 		data = JSON.stringify(data);
-		const  response = `HTTP/1.1 200 OK\nContent-Type: application/json\n\n${data}`;
-		this.send(response);
+		const  response = `HTTP/1.1 ${this.statusCode} ${this.statusTextMap[this.statusCode]}\nContent-Type: application/json\n\n${data}`;
+		this.socket.write(response); // Send the complete response
+        this.socket.end(); // End the connection
 	}
 }
 

--- a/test/init.js
+++ b/test/init.js
@@ -1,10 +1,31 @@
-const   Server=  require('../server/index.js')
+const  Server=  require('../server/index.js')
 const  server  =  new Server()
 
 server.get("/",(req,res)=>{
 	console.log(req)
-	res.json({status:200})
+	res.status(200).json({status:200})
 })
+
+server.post("/",(req,res)=>{
+	console.log(req)
+	res.status(201).json({status:201})
+})
+
+server.put("/",(req,res)=>{
+	console.log(req)
+	res.status(202).json({status:202})
+})
+
+server.patch("/",(req,res)=>{
+	console.log(req)
+	res.status(200).json({status:200})
+})
+
+server.delete("/",(req,res)=>{
+	console.log(req)
+	res.status(204).json({status:204})
+})
+
 server.listen(8080,()=>{
 	console.log("test")
 })


### PR DESCRIPTION
### 🔨 feature/http-req-res

I have updated `server/index.js` and `server/response.js`. Refactored `Response` class-methods to avoid the header-definition conflicts for `json()` and `send()` .

issue: #11 

Now we can have the seven major HTTP methods:
- GET
- POST
- PUT *(newly added)*
- PATCH *(newly added)*
- DELETE *(newly added)*
- HEAD *(newly added)*
- OPTIONS *(newly added)* 

Also, can send json response in a express-js like chained way:
```js
server.get("/", (req,res)=>{
    console.log(req)
    res.status(200).json({status:200}) // new-way
})

server.post("/", (req,res)=>{
    console.log(req)
    res.status(201).json({status:201}) // new-way
})
```
Their sample response screenshots:
![Screenshot at 23-02-50](https://github.com/user-attachments/assets/dd9d4ba8-2e59-49f9-b1a5-993b766f42fc)
![Screenshot at 23-03-18](https://github.com/user-attachments/assets/6f1427c8-9d9f-43cc-9490-93cbca1b901f)

Hope you (@IntegerAlex) liked it 👍🏼 
~/mahabubx7
